### PR TITLE
Add missing annotations to TimelineScene return types

### DIFF
--- a/lib/timeline_tween/timeline_tween.dart
+++ b/lib/timeline_tween/timeline_tween.dart
@@ -167,7 +167,7 @@ class TimelineScene<T> {
   final Duration begin;
   final Duration duration;
   final Curve curve;
-  final TimelineTween parent;
+  final TimelineTween<T> parent;
 
   final items = <_SceneItem<T>>[];
 
@@ -180,7 +180,7 @@ class TimelineScene<T> {
   ///
   /// The begin and end time is also taken from the scene but can be fine-tuned
   /// by defining [shiftBegin] and [shiftEnd].
-  TimelineScene animate(
+  TimelineScene<T> animate(
     T property, {
     Animatable tween,
     Curve curve,
@@ -205,7 +205,7 @@ class TimelineScene<T> {
   ///
   /// By default the scene uses a linear easing curve for all it's animated
   /// properties. This can be change by specifying a [curve].
-  TimelineScene addSubsequentScene({
+  TimelineScene<T> addSubsequentScene({
     Duration duration,
     Duration delay = Duration.zero,
     Curve curve,


### PR DESCRIPTION
A couple of missing <T>s were leading to the analyzer inferring `TimelineScene<dynamic>` on the returns from `TimelineScene.animate` and `TimelineScene.addSubsequentScene`.

Fixes #61

All tests are passing.