### PR TITLE
Move flutter_lints to dev_dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_lints: ^1.0.4
   collection: ^1.15.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^1.0.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
Having flutter_lints as a dependency can cause conflicts for users using a higher constraint. Move it to dev_dependencies as there's no real reason (?) to have it among dependencies. It's also the recommended way to add it as per https://github.com/flutter/packages/blob/master/packages/flutter_lints/README.md